### PR TITLE
Add web frontend support for '.local' domains

### DIFF
--- a/web-root/np2/js/websocket_channel.mjs
+++ b/web-root/np2/js/websocket_channel.mjs
@@ -247,7 +247,8 @@ isPrivateIPaddress_ (ipaddress) {
     let parts = ipaddress.split('.');
     return parts[0] === '10' ||
         (parts[0] === '172' && (parseInt(parts[1], 10) >= 16 && parseInt(parts[1], 10) <= 31)) ||
-        (parts[0] === '192' && parts[1] === '168');
+        (parts[0] === '192' && parts[1] === '168') ||
+        (parts[parts.length - 1].split(':')[0] === 'local');
 }
 
 }; // class


### PR DESCRIPTION
On Mac OS, by default, it's possible to reach a RasPi on your local network at its `hostname.local` domain, ie. `http://mypihostname.local:8889/np2/`. When I try to load the RWS control panel this way, the webpage loads but it fails the `isPrivateIPaddress` check when initiating a websocket connection. This change updates the `isPrivateIPaddress` function to return true if the host domain ends in `.local`.